### PR TITLE
Add PikaPods as additional hosting option.

### DIFF
--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -1,6 +1,7 @@
 - [🚀 Installer](#-installer-via-cli)
 - [🐳 Docker](#-docker)
 - [💪🏻 Without Docker](#-without-docker-recommended-for-x86x64-only)
+- [☁️ Unofficial Install- and Hosting Options](#unofficial--experimental)
 
 ## 🚀 Installer via CLI
 
@@ -114,7 +115,7 @@ https://github.com/louislam/uptime-kuma/wiki/Reverse-Proxy
   Install with Portainer
 
 
-## Unofficial & Experiment
+## Unofficial & Experimental
 
 ⚠ ⚠ ⚠ Warning: Generally, I only test Docker and Node.js. All installation methods here may be broken in the future release. I don't maintain them. Use at your own risk.
 
@@ -134,6 +135,12 @@ https://github.com/louislam/uptime-kuma/tree/ansible-unofficial/ansible
 Unofficial tutorial by Marius Bogdan Lixandru:
 
 https://mariushosting.com/how-to-install-uptime-kuma-on-your-synology-nas/
+
+### One-Click Hosting on PikaPods
+
+Run with one click on [PikaPods.com](https://www.pikapods.com/). Free for about 3 months with welcome credit.
+
+[![PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=uptime-kuma)
 
 ### Termux (Unofficial/Experiment)
 


### PR DESCRIPTION
This PR adds [PikaPods.com](https://www.pikapods.com/) as additional one-click install option. 

About PikaPods: Our mission is to make great open source apps, like Uptime-Kuma more accessible and easier to get started with. Our users love Uptime-Kuma and hundreds of them are running it already (mostly using their free beta- or welcome credits). We also have a big audience in China and already ordered our first Hong Kong server to provide lower latency.

So I'm suggesting to add PikaPods as additional install option to the docs as well. This would help an even wider audience to benefit from the project.

[Preview](https://github.com/m3nu/uptime-kuma-wiki/blob/misc/add-pikapods-hosting/%F0%9F%94%A7-How-to-Install.md#one-click-hosting-on-pikapods)