### PR TITLE
add: unofficial rootless Helm 3 Chart

### DIFF
--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -132,6 +132,15 @@ https://github.com/louislam/uptime-kuma/wiki/Reverse-Proxy
 
 See more [here](https://github.com/louislam/uptime-kuma/tree/k8s-unofficial/kubernetes) 
 
+### ☸️ OpenShift 4 and Kubernetes Helm 3 Chart (Unofficial)
+
+> Note: This Chart relies on a repackaged OCI Container Image, which lets *uptime-kuma* run as **non-root** user. \
+> The entire repackage process is automated via GitHub Actions and renovate-bot keeps everything up to date. (feel free to audit it yourself)
+
+The Containerfile used to rebundle *uptime-kuma*: [rootless Containerfile](https://github.com/k3rnelpan1c-dev/uptime-kuma-helm/blob/main/container/Containerfile)
+
+https://github.com/k3rnelpan1c-dev/uptime-kuma-helm
+
 ### Ansible (Unofficial)
 
 https://github.com/louislam/uptime-kuma/tree/ansible-unofficial/ansible


### PR DESCRIPTION
This PR aims to add the Unofficial rootless Helm 3 Chart, which I maintain, to the unofficial install section.

Hope the bit of extra text is okay, but mentioning the rootless/non-root bit is crucial (context: https://github.com/louislam/uptime-kuma/pull/1769).