### PR TITLE
Add a oneliner to update Kuma without docker

### DIFF
--- a/🆙-How-to-Update.md
+++ b/🆙-How-to-Update.md
@@ -32,7 +32,7 @@ docker-compose up -d --force-recreate
 This oneliner require jq command 
 
 ```bash
-cd <uptime-kuma-directory> && git fetch --all && git checkout $(curl --silent "https://api.github.com/repos/louislam/uptime-kuma/releases/latest" | jq -r '.tag_name') --force && npm install --omit=dev && npm run download-dist
+cd <uptime-kuma-directory> && git fetch --all && git checkout $(curl --silent "https://api.github.com/repos/louislam/uptime-kuma/releases/latest" | jq -r '.tag_name') --force && npm install --omit=dev && npm run download-dist && pm2 restart uptime-kuma
 ```
 
 ## 🆙 💪🏻 Non-Docker

--- a/🆙-How-to-Update.md
+++ b/🆙-How-to-Update.md
@@ -27,6 +27,14 @@ docker stop uptime-kuma
 docker-compose up -d --force-recreate
 ```
 
+## 🆙 💪🏻 Non-Docker with JQ (oneliner)
+
+This oneliner require jq command 
+
+```bash
+cd <uptime-kuma-directory> && git fetch --all && git checkout $(curl --silent "https://api.github.com/repos/louislam/uptime-kuma/releases/latest" | jq -r '.tag_name') --force && npm install --omit=dev && npm run download-dist
+```
+
 ## 🆙 💪🏻 Non-Docker
 
 ```bash


### PR DESCRIPTION
The addition made in this PR aims to automate a little more the update of Kuma and also to allow not to have to maintain this documentation with each version change.

It's work fine 

```bash
kuma@blackpearl:~$ cd uptime-kuma/ && git fetch --all && git checkout $(curl --silent "https://api.github.com/repos/louislam/uptime-kuma/releases/latest" | jq -r '.tag_name') --force && npm install --omit=dev && npm run download-dist
Fetching origin
HEAD is now at b8e8c1b9 Update to 1.19.3

up to date, audited 512 packages in 10s

67 packages are looking for funding
  run `npm fund` for details

7 vulnerabilities (4 moderate, 3 high)

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

> uptime-kuma@1.19.3 download-dist
> node extra/download-dist.js

Downloading dist
https://github.com/louislam/uptime-kuma/releases/download/1.19.3/dist.tar.gz
https://objects.githubusercontent.com/github-production-release-asset-2e65be/382496361/50e38a2c-5779-41e9-bfb9-4072dc725a17?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230103%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230103T122154Z&X-Amz-Expires=300&X-Amz-Signature=bc82f405bdca6d1589ff7ae1ef332318f2dfd329e136c4679d18c239178cfca8&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=382496361&response-content-disposition=attachment%3B%20filename%3Ddist.tar.gz&response-content-type=application%2Foctet-stream
Extracting dist...
Done
``` 