### PR TITLE
Fixed which field isn't set for API key auth

### DIFF
--- a/API-Keys.md
+++ b/API-Keys.md
@@ -61,4 +61,4 @@ Here is an example config for Prometheus:
       password: <api key>
 ```
 
-Note: we don't need to set a password field as it is not used.
+Note: we don't need to set a username field as it is not used.


### PR DESCRIPTION
Fixed a mistake in #31 which stated that the password field didn't need to be set. This should have been the username field.