### PR TITLE
Fix caddy-docker-proxy configuration

### DIFF
--- a/Reverse-Proxy.md
+++ b/Reverse-Proxy.md
@@ -119,7 +119,7 @@ services:
       - /srv/uptime:/app/data
     labels:   
       caddy: status.example.org
-      caddy.reverse_proxy: "* {{ '{{upstreams 3001}}'}}"
+      caddy.reverse_proxy: "{{upstreams 3001}}"
   caddy:
     image: "lucaslorentz/caddy-docker-proxy:ci-alpine"
     ports:    


### PR DESCRIPTION
Previous configuration was throwing `template: :1: malformed character constant: '{{upstreams 3001}}'`

Fixed it based on caddy-docker-proxy's readme

https://github.com/lucaslorentz/caddy-docker-proxy/blob/master/README.md#reverse-proxy-examples