### PR TITLE
Update caddy docker-compose example

### DIFF
--- a/Reverse-Proxy.md
+++ b/Reverse-Proxy.md
@@ -119,7 +119,7 @@ services:
       - /srv/uptime:/app/data
     labels:   
       caddy: status.example.org
-      caddy.reverse_proxy: "* {{ '{{upstreams 3001}}'}}"
+      caddy.reverse_proxy: "* {{upstreams 3001}}"
   caddy:
     image: "lucaslorentz/caddy-docker-proxy:ci-alpine"
     ports:    


### PR DESCRIPTION
I just setup caddy as a reverse proxy for Kuma using lucaslorentz/caddy-docker-proxy and noticed a typo in your suggested config. Here's a working fix!