### PR TITLE
adding metrics_path to snippet

### DIFF
--- a/Prometheus-Integration.md
+++ b/Prometheus-Integration.md
@@ -20,6 +20,7 @@ Put the following into your Prometheus config:
   - job_name: 'uptime'
     scrape_interval: 30s
     scheme: http
+    metrics_path: '/metrics'
     static_configs:
       - targets: ['uptime-kuma.url']
     basic_auth: # Only needed if authentication is enabled (default) 


### PR DESCRIPTION
Adding a change to the prometheus config snippet, it should contain:

`metrics_path: '/metrics'`

Putting the target url with the "/metrics" in it will prevent prometheus from loading.