### PR TITLE
Update 🆙-How-to-Update.md

### DIFF
--- a/🆙-How-to-Update.md
+++ b/🆙-How-to-Update.md
@@ -31,6 +31,9 @@ docker compose up -d --force-recreate
 ```bash
 cd <uptime-kuma-directory>
 
+# Backup dist directory
+mv dist dist-$(date +%Y%m%d-%H%M%S)
+
 # Update from git
 git fetch --all
 git checkout 1.22.0 --force


### PR DESCRIPTION
Add a step in the manual upgrade to move the dist folder as without moving it, upgrades fail partially as the backend and frontend get out of sync.

This is what I do in my local script to ensure a smooth upgrade.