### PR TITLE
Fixed `INFO` not being a possible tag for warnings

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -1,7 +1,7 @@
 
 ## Uptime Kuma reports `DOWN`, but the service can be accessed
 
-> [!INFO]
+> [!TIP]
 > In case you did not know: 
 > docker has [more than one network type](https://youtu.be/bKFMS5C4CG0) with only some of them allowing access to the local network and some not even allowing access to remote networks
 


### PR DESCRIPTION
Before: 
![image](https://github.com/louislam/uptime-kuma-wiki/assets/26258709/3fd00ad7-2025-47ea-b662-76a673edf536)

After:
![image](https://github.com/louislam/uptime-kuma-wiki/assets/26258709/bc611b5e-c576-4d85-8a2b-bd9502633143)
