### PR TITLE
 Improve Docker Host TLS Wiki relate to #4426 and Add Troubleshooting IPv6 for Docker

### DIFF
--- a/How-to-Monitor-Docker-Containers.md
+++ b/How-to-Monitor-Docker-Containers.md
@@ -87,6 +87,11 @@ Add a new Docker host and choose TCP as the option. Specify the IP address of th
 
 Assuming you have already properly configured your remote docker instance to listen securely for TLS connections as detailed [here](https://docs.docker.com/engine/security/protect-access/#use-tls-https-to-protect-the-docker-daemon-socket), you must configure Uptime-Kuma to use the certificates you've generated.  The base path where certificates are looked for can be set with the `DOCKER_TLS_DIR_PATH` environmental variable or defaults to `data/docker-tls/`. 
 
+For running uptime-kuma inside docker, mount the parent directory to `/app/data/docker-tls`. 
+```
+-v /docker-cert:/app/data/docker-tls
+```
+
 If a directory in this path exists with a name matching the FQDN of the docker host (e.g. the FQDN of `https://example.com:2376` is `example.com` so the directory `data/docker-tls/example.com/` would be searched for certificate files), then `ca.pem`, `key.pem` and `cert.pem` files are loaded and included in the agent options. File names can also be overridden via `DOCKER_TLS_FILE_NAME_(CA|KEY|CERT)`.
 
 

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -26,3 +26,7 @@ Examples:
 curl https://google.com
 ping google.com
 ```
+
+### IPv6
+If you are running Uptime Kuma on top of Docker and the service can only be access via IPv6. Please follow the Docker's [official wiki](https://docs.docker.com/config/daemon/ipv6/) to enable IPv6 support.  
+IPv6 are not supported out of the box on Docker. 


### PR DESCRIPTION
Hello, 

This pull request improved Docker Host TLS wiki portion relate to [#4426](https://github.com/louislam/uptime-kuma/issues/4426), https://github.com/louislam/uptime-kuma/issues/4426#issuecomment-1913158150

Also add troubleshooting IPv6 for Docker. 

Cheers! 