### PR TITLE
add tls=false flag to insecure option

### DIFF
--- a/How-to-Monitor-Docker-Containers.md
+++ b/How-to-Monitor-Docker-Containers.md
@@ -31,6 +31,7 @@ Update the daemon configuration located at `/etc/docker/daemon.json`:
    #any additional parameters should be kept
 
    #Insecure option, only use this if you are running on a closed network
+   "tls": false,
    "hosts": ["unix:///var/run/docker.sock", "tcp://<host IP address>:2375"]
 
    #Secure option


### PR DESCRIPTION
During testing, after creation of ```/etc/docker/daemon.json``` and using the insecure method, the Docker service would not start without ```"tls": false``` flag, even after applying suggestion to update the ```docker.service``` file.