### PR TITLE
Update 3rd Party page

### DIFF
--- a/3rd-Party-Addons-Apps.md
+++ b/3rd-Party-Addons-Apps.md
@@ -1,19 +1,20 @@
 A list of 3rd party addons or applications, plugins or related side projects.
 
-Feel free to add your project here by making a pull request in this wiki repo: https://github.com/louislam/uptime-kuma-wiki
+Feel free to add your project here by making a pull request in [this wiki's repo](https://github.com/louislam/uptime-kuma-wiki):
 
+- [AutoKuma](https://github.com/BigBoot/AutoKuma) - Automates the creation of Monitors based on Docker container labels. Additionally provides a CLI for Uptime Kuma.
+- [GEA](https://github.com/mrjones-plip/GEA) - A docker app that monitors your domains for expiration.  A JSON feed is exposed over HTTP which Uptime Kuma monitor and alert on via the `HTTP(s) Json Query` feature. 
+- [KumaCompanion](https://github.com/Zerka30/KumaCompanion) - A Command Line Interface (CLI) for Uptime Kuma
+- [MMM-AuthenticatedUptimeKuma](https://github.com/totoluto/MMM-AuthenticatedUptimeKuma) - A MagicMirror² module which allows you to display the status of your monitors on your mirror in different ways
 - [Streamdeck Uptime Kuma](https://github.com/MarlBurroW/Streamdeck-Uptime-Kuma) - An Uptime Kuma plugin for Elgato Streamdeck
-- [xBarApp Uptime Kuma](https://github.com/mariogarridopt/xBar-Uptime-Kuma) - An Uptime Kuma plugin for xBarApp for Mac
 - [Uptime Kuma Manager](https://apps.apple.com/us/app/uptime-kuma-manager/id6446004887) - An iOS app that allows you to connect to your Uptime Kuma servers and monitor the services directly from your phone.
+- [Uptime Kuma Push Agent](https://github.com/manprinsen/uptime-kuma-agent) - A lightweight monitoring agent with Go, Python, and shell implementations, designed to send network uptime data to Uptime Kuma's Push Monitor.
+- [Uptime Mate](https://github.com/schech1/uptime-buddy) - An Uptime Kuma monitoring tool for Apple Watch.
+- [UptimeKumaRemoteProbe](https://github.com/zimbres/UptimeKumaRemoteProbe) - A Remote Probe to work with Uptime Kuma "Push" monitor type.
 - [Wuma - Uptime Kuma iOs Manager](https://apps.apple.com/app/wuma-uptime-kuma-manager/id1662404144) - An iOS app that allows you to monitor Uptime Kuma from your iPhone, iPad, and Apple Watch. Wuma adds iOS widgets and provides real-time notifications when services go down.
 - [kuma-repoter](https://github.com/ghinknet/kuma-repoter) - A simple go reporter to send requests to Uptime Kuma's "Push" monitor
+- [kuma-sentinel](https://github.com/Coronon/kuma-sentinel) - Provides advanced push-based monitor types for even more insights and control.
+- [swatchdog](https://github.com/imsingee/swatchdog) - A simple requester to send periodically requests to Uptime Kuma's "Push" monitor
 - [uptime-kuma-api (Python)](https://github.com/lucasheld/uptime-kuma-api) - A wrapper for the Uptime Kuma Socket.IO API
 - [uptimekuma-migrator](https://github.com/Peppershade/uptimekuma-migrator) - Simple migrator from UptimeRobot to UptimeKuma
-- [swatchdog](https://github.com/imsingee/swatchdog) - A simple requester to send periodically requests to Uptime Kuma's "Push" monitor
-- [KumaCompanion](https://github.com/Zerka30/KumaCompanion) - A Command Line Interface (CLI) for Uptime Kuma
-- [UptimeKumaRemoteProbe](https://github.com/zimbres/UptimeKumaRemoteProbe) - A Remote Probe to work with Uptime Kuma "Push" monitor type.
-- [AutoKuma](https://github.com/BigBoot/AutoKuma) - Automates the creation of Monitors based on Docker container labels. Additionally provides a CLI for Uptime Kuma.
-- [Uptime Mate](https://github.com/schech1/uptime-buddy) - An Uptime Kuma monitoring tool for Apple Watch.
-- [Uptime Kuma Push Agent](https://github.com/manprinsen/uptime-kuma-agent) - A lightweight monitoring agent with Go, Python, and shell implementations, designed to send network uptime data to Uptime Kuma's Push Monitor.
-- [MMM-AuthenticatedUptimeKuma](https://github.com/totoluto/MMM-AuthenticatedUptimeKuma) - A MagicMirror² module which allows you to display the status of your monitors on your mirror in different ways
-- [kuma-sentinel](https://github.com/Coronon/kuma-sentinel) - Provides advanced push-based monitor types for even more insights and control.
+- [xBarApp Uptime Kuma](https://github.com/mariogarridopt/xBar-Uptime-Kuma) - An Uptime Kuma plugin for xBarApp for Mac

--- a/3rd-Party-Addons-Apps.md
+++ b/3rd-Party-Addons-Apps.md
@@ -3,7 +3,7 @@ A list of 3rd party addons or applications, plugins or related side projects.
 Feel free to add your project here by making a pull request in [this wiki's repo](https://github.com/louislam/uptime-kuma-wiki):
 
 - [AutoKuma](https://github.com/BigBoot/AutoKuma) - Automates the creation of Monitors based on Docker container labels. Additionally provides a CLI for Uptime Kuma.
-- [GEA](https://github.com/mrjones-plip/GEA) - A docker app that monitors your domains for expiration.  A JSON feed is exposed over HTTP which Uptime Kuma monitor and alert on via the `HTTP(s) Json Query` feature. 
+- [GEA](https://github.com/mrjones-plip/GEA) - A docker app that monitors your domains for expiration.  A JSON feed is exposed over HTTP which Uptime Kuma can monitor and alert on via the `HTTP(s) Json Query` feature. 
 - [KumaCompanion](https://github.com/Zerka30/KumaCompanion) - A Command Line Interface (CLI) for Uptime Kuma
 - [MMM-AuthenticatedUptimeKuma](https://github.com/totoluto/MMM-AuthenticatedUptimeKuma) - A MagicMirror² module which allows you to display the status of your monitors on your mirror in different ways
 - [Streamdeck Uptime Kuma](https://github.com/MarlBurroW/Streamdeck-Uptime-Kuma) - An Uptime Kuma plugin for Elgato Streamdeck


### PR DESCRIPTION
This PR updates the [3rd party page](https://github.com/louislam/uptime-kuma/wiki/3rd-Party-Addons-Apps):
* Adds a new project: [GEA](https://github.com/mrjones-plip/GEA)
* alphabetize list
* move the wiki GH repo URL to be a link for better legibility 

The description for the new app is:

> [GEA](https://github.com/mrjones-plip/GEA) - A docker app that monitors your domains for expiration.  A JSON feed is exposed over HTTP which Uptime Kuma can monitor and alert on via the `HTTP(s) Json Query` feature. 