### PR TITLE
Remove Ansible section from installation guide

### DIFF
--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -99,10 +99,6 @@ The Containerfile used to rebundle _uptime-kuma_: [rootless Containerfile](https
 
 https://github.com/k3rnelpan1c-dev/uptime-kuma-helm
 
-#### Ansible
-
-https://github.com/louislam/uptime-kuma/tree/ansible-unofficial/ansible
-
 #### Home Assistant Add-on
 
 https://github.com/hassio-addons/addon-uptime-kuma


### PR DESCRIPTION
Removed Ansible section and related links from the installation guide.

It seems that no one maintains it for more than 3 years, to avoid confusion, it is time to drop it.

In case someone still need this for some reason:
https://github.com/louislam/uptime-kuma/tree/c742153d4dc06df817386c85abaa63d6cc5b4cfe/ansible