### PR TITLE
Change password to API key in Prometheus config

### DIFF
--- a/Prometheus-Integration.md
+++ b/Prometheus-Integration.md
@@ -27,6 +27,7 @@ Put the following into your Prometheus config:
       username: <your user>
       password: <your password>
 ```
+
 > [!TIP]
 > You can also authenticate using an [API Key](API-Keys.md#authenticating-using-an-api-key) instead.
 > As soon as you add your first API key, the use of basic authentication for the endpoint will be permanently disabled.


### PR DESCRIPTION
Updated the password field to reference the API key instead of a password. Password didn't work with version 2.0.2, creating an API key and using that successfully worked.