### PR TITLE
Add Cloudron as unofficial installation method

### DIFF
--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -187,7 +187,7 @@ You can [host uptime-kuma](https://flashpanel.io/docs/v2/en/tutorial/uptime-kuma
 
 server.camp offers paid, EU-based, GDPR-compliant [hosting of uptime-kuma](https://server.camp/product/uptimekuma) and other open-source software for startups, small- and large business. You can get a 7-day trial at no cost.
 
-#### Uptime Kuma on Cloudron
+#### [Cloudron.io](https://www.cloudron.io/)
 
 [![Install](https://cloudron.io/img/button.svg)](https://www.cloudron.io/store/louislam.uptimekuma.app.html)
 


### PR DESCRIPTION
# Hello Uptime Kuma Contributors 👋🏻

Firstly, thanks for this awesome software!

I am from the [Cloudron Community](https://forum.cloudron.io/) and use Uptime Kuma on Cloudron since 2023 and to be more precise, since Uptime Kuma version [1.20.0](https://forum.cloudron.io/post/61958).

Since I only ever used Cloudron to host my own Uptime Kuma I would love to have Cloudron added to the official uptime kuma installation wiki in the Server Hosting Platforms section.

Thanks for reading my PR and if there is anything you would like to have changed, please let me know.


Cheers
~BrutalBirdie