### PR TITLE
docs: include link to uptime-kuma-aws tf module

### DIFF
--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -101,7 +101,7 @@ https://github.com/k3rnelpan1c-dev/uptime-kuma-helm
 
 #### AWS Terraform Module (Unofficial)
 
-Serverless deployment of uptime-kuma on AWS using Terraform: https://github.com/paliwalvimal/uptime-kuma-aws
+Deployment template of uptime-kuma on AWS using Terraform: https://github.com/paliwalvimal/uptime-kuma-aws
 
 #### Home Assistant Add-on
 

--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -99,6 +99,10 @@ The Containerfile used to rebundle _uptime-kuma_: [rootless Containerfile](https
 
 https://github.com/k3rnelpan1c-dev/uptime-kuma-helm
 
+#### AWS Terraform Module (Unofficial)
+
+Serverless deployment of uptime-kuma on AWS using Terraform: https://github.com/paliwalvimal/uptime-kuma-aws
+
 #### Home Assistant Add-on
 
 https://github.com/hassio-addons/addon-uptime-kuma


### PR DESCRIPTION
add link to uptime-kuma-aws tf module that allows serverless deployment of uptime-kuma tool on aws cloud

closes #148