### PR TITLE
docs(install): add HelmForge Uptime Kuma chart

### DIFF
--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -90,12 +90,7 @@ Please read wiki for more info: https://github.com/louislam/uptime-kuma/wiki/Rev
 
 ### Deployment Tools
 
-#### ☸️ Kubernetes Helm Chart with HelmForge (Unofficial)
-
-> [!NOTE]
-> This chart uses the official `louislam/uptime-kuma` image — no custom or repackaged container.
-
-Community-maintained Helm chart for Kubernetes users:
+#### Kubernetes Helm Chart with HelmForge (Unofficial)
 
 - Chart source: https://github.com/helmforgedev/charts/tree/main/charts/uptime-kuma
 - Artifact Hub: https://artifacthub.io/packages/helm/helmforge/uptime-kuma
@@ -107,18 +102,15 @@ helm repo add helmforge https://repo.helmforge.dev
 helm install uptime-kuma helmforge/uptime-kuma
 ```
 
-Or install via OCI:
+Or via OCI
 
 ```bash
 helm install uptime-kuma oci://ghcr.io/helmforgedev/helm/uptime-kuma
 ```
 
 Features:
-
-- uses the official upstream `louislam/uptime-kuma` image with pinned version tags
 - supports both SQLite and MariaDB backends
 - includes built-in S3-compatible backup workflows
-- published via both Helm repository and OCI with Cosign signatures
 
 #### AWS Terraform Module (Unofficial)
 

--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -99,6 +99,35 @@ The Containerfile used to rebundle _uptime-kuma_: [rootless Containerfile](https
 
 https://github.com/k3rnelpan1c-dev/uptime-kuma-helm
 
+#### ☸️ Kubernetes Helm Chart with HelmForge (Unofficial)
+
+Community-maintained Helm chart for Kubernetes users:
+
+- Chart source: https://github.com/helmforgedev/charts/tree/main/charts/uptime-kuma
+- Artifact Hub: https://artifacthub.io/packages/helm/helmforge/uptime-kuma
+
+Install with the Helm repository:
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm install uptime-kuma helmforge/uptime-kuma
+```
+
+Or install via OCI:
+
+```bash
+helm install uptime-kuma oci://ghcr.io/helmforgedev/helm/uptime-kuma
+```
+
+Notable differences compared to the OpenShift/rootless chart above:
+
+- actively maintained
+- supports both SQLite and MariaDB backends
+- includes built-in S3-compatible backup workflows
+- published via both Helm repository and OCI
+
+There are multiple community Helm chart efforts for Kubernetes users. The OpenShift/rootless chart above is focused on non-root OpenShift-compatible operation, while the HelmForge chart is focused on more general Kubernetes defaults and backup-oriented operations.
+
 #### AWS Terraform Module (Unofficial)
 
 Deployment template of uptime-kuma on AWS using Terraform: https://github.com/paliwalvimal/uptime-kuma-aws

--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -90,16 +90,10 @@ Please read wiki for more info: https://github.com/louislam/uptime-kuma/wiki/Rev
 
 ### Deployment Tools
 
-#### ☸️ OpenShift 4 and Kubernetes Helm 3 Chart (Unofficial)
+#### ☸️ Kubernetes Helm Chart with HelmForge (Unofficial)
 
 > [!NOTE]
-> This Chart relies on a repackaged OCI Container Image, which lets _uptime-kuma_ run as **non-root** user. The entire repackage process is automated via GitHub Actions and renovate-bot keeps everything up to date. (feel free to audit it yourself)
-
-The Containerfile used to rebundle _uptime-kuma_: [rootless Containerfile](https://github.com/k3rnelpan1c-dev/uptime-kuma-helm/blob/main/container/Containerfile)
-
-https://github.com/k3rnelpan1c-dev/uptime-kuma-helm
-
-#### ☸️ Kubernetes Helm Chart with HelmForge (Unofficial)
+> This chart uses the official `louislam/uptime-kuma` image — no custom or repackaged container.
 
 Community-maintained Helm chart for Kubernetes users:
 
@@ -119,14 +113,12 @@ Or install via OCI:
 helm install uptime-kuma oci://ghcr.io/helmforgedev/helm/uptime-kuma
 ```
 
-Notable differences compared to the OpenShift/rootless chart above:
+Features:
 
-- actively maintained
+- uses the official upstream `louislam/uptime-kuma` image with pinned version tags
 - supports both SQLite and MariaDB backends
 - includes built-in S3-compatible backup workflows
-- published via both Helm repository and OCI
-
-There are multiple community Helm chart efforts for Kubernetes users. The OpenShift/rootless chart above is focused on non-root OpenShift-compatible operation, while the HelmForge chart is focused on more general Kubernetes defaults and backup-oriented operations.
+- published via both Helm repository and OCI with Cosign signatures
 
 #### AWS Terraform Module (Unofficial)
 


### PR DESCRIPTION
## Summary
- add HelmForge as an unofficial Helm chart option for Kubernetes users
- document installation via Helm repository and OCI
- explain how it differs from the existing OpenShift/rootless chart already listed in the wiki

## Notes
- keeps the wording aligned with existing community-maintained options
- does not present HelmForge as an official deployment method
- highlights maintenance status and focus differences without dismissing other community efforts