### PR TITLE
Added KumaSentinel to 3rd party addons

### DIFF
--- a/3rd-Party-Addons-Apps.md
+++ b/3rd-Party-Addons-Apps.md
@@ -27,4 +27,4 @@ Feel free to add your project here by making a pull request in [this wiki's repo
 - [UptimeKuma Agent](https://github.com/luyii-code-1/UptimeKuma_Agent) - A client that lets UptimeKuma monitor everything via Push—Bash commands, websites, Systemd status, and even Mi Home sensor statuses.
 - [Uptime Kuma Notifier](https://github.com/unicornops/uptime-kuma-notifier) - A macOS menu bar app that displays the status of your Uptime Kuma monitors and sends notifications when their status changes.
 - [KumaUptime (macOS)](https://github.com/CallumJRobertson/Kuma-Uptime-Manager-MacOS) - A native macOS menu bar app for monitoring Uptime Kuma servers. Supports private API mode, public status pages, notifications, and in-app monitor creation.
-- [KumaSentinel](https://github.com/ourpxi/KumaSentinel) - A simple python script to post incident and maintenance updates to Dscord via webhooks
+- [KumaBroadcast](https://github.com/ourpxi/KumaBroadcast) - A simple python script to post incident and maintenance updates to Dscord via webhooks

--- a/3rd-Party-Addons-Apps.md
+++ b/3rd-Party-Addons-Apps.md
@@ -27,3 +27,4 @@ Feel free to add your project here by making a pull request in [this wiki's repo
 - [UptimeKuma Agent](https://github.com/luyii-code-1/UptimeKuma_Agent) - A client that lets UptimeKuma monitor everything via Push—Bash commands, websites, Systemd status, and even Mi Home sensor statuses.
 - [Uptime Kuma Notifier](https://github.com/unicornops/uptime-kuma-notifier) - A macOS menu bar app that displays the status of your Uptime Kuma monitors and sends notifications when their status changes.
 - [KumaUptime (macOS)](https://github.com/CallumJRobertson/Kuma-Uptime-Manager-MacOS) - A native macOS menu bar app for monitoring Uptime Kuma servers. Supports private API mode, public status pages, notifications, and in-app monitor creation.
+- [KumaSentinel](https://github.com/ourpxi/KumaSentinel) - A simple python script to post incident and maintenance updates to Dscord via webhooks


### PR DESCRIPTION
I made this for personal use and thought it might be user to someone, however I did not realize kuma-sentinel name was already in use, I can rename the repo if there is an issue with the name being duplicated

My KumaSentinel script is a simple python script to scrape incident and maintenance updated from status pages and post them to discord via webhooks
I made this in like an hour as the only solution I could come up with for a way to automatically send the incidents posted in the status page to discord as well as the maintenance updates

Yes I rather code for a couple hours than use 4 more seconds to copy and paste the info into discord