### PR TITLE
Update How-to-Monitor-Docker-Containers.md always limit docker.socket access to read-only

### DIFF
--- a/How-to-Monitor-Docker-Containers.md
+++ b/How-to-Monitor-Docker-Containers.md
@@ -12,14 +12,14 @@ By default, a docker container is self-contained, which means Uptime Kuma cannot
 Command argument:
 
 ```bash
--v /var/run/docker.sock:/var/run/docker.sock
+-v /var/run/docker.sock:/var/run/docker.sock:ro
 ```
 
 docker-compose:
 
 ```yml
 volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
+    - /var/run/docker.sock:/var/run/docker.sock:ro
 ```
 
 ### (Method 2) TCP - Bridge Mode


### PR DESCRIPTION
Please never publish any docker.sock in read/write mode, at least put :ro at the end.
Also consider to define the permissions kuma needs to monitor containers and block the rest, like done in https://github.com/Tecnativa/docker-socket-proxy 

environment:
    ALLOW_RESTARTS=0 \
    ALLOW_STOP=0 \
    ALLOW_START=0 \
    AUTH=0 \
    BUILD=0 \
    COMMIT=0 \
    CONFIGS=0 \
    CONTAINERS=1 \.  <-- only this one you probably need.
    DISABLE_IPV6=0 \
    DISTRIBUTION=0 \
    EVENTS=1 \
    EXEC=0 \
    GRPC=0 \
    IMAGES=0 \
    INFO=0 \
    LOG_LEVEL=info \
    NETWORKS=0 \
    NODES=0 \
    PING=1 \
    PLUGINS=0 \
    POST=0 \
    SECRETS=0 \
    SERVICES=0 \
    SESSION=0 \
    SOCKET_PATH=/var/run/docker.sock \
    SWARM=0 \
    SYSTEM=0 \
    TASKS=0 \
    VERSION=1 \
    VOLUMES=0