### PR TITLE
Adding example for ipv6 in compose

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -28,3 +28,24 @@ ping google.com
 
 If you are running Uptime Kuma on top of Docker and the service can only be access via IPv6. Please follow the Docker's [official wiki](https://docs.docker.com/config/daemon/ipv6/) to enable IPv6 support.\
 IPv6 are not supported out of the box on Docker.
+
+For docker compose, this is as simple as adding a network with IPv6 enabled to your compose file. Upating the template from the project would look like this:
+
+```yaml
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    volumes:
+      - ./data:/app/data
+    ports:
+      # <Host Port>:<Container Port>
+      - 3001:3001
+    restart: unless-stopped
+    networks:
+      - uptime-kuma-net
+networks:
+  uptime-kuma-net:
+    enable_ipv6: true
+```
+
+The network is created at the bottom, with `enable_ipv6: true` and then added to the service. 

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -34,7 +34,7 @@ For docker compose, this is as simple as adding a network with IPv6 enabled to y
 ```diff
   services:
     uptime-kuma:
-      image: louislam/uptime-kuma:1
+      image: louislam/uptime-kuma:2
       volumes:
         - ./data:/app/data
       ports:

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -31,21 +31,21 @@ IPv6 are not supported out of the box on Docker.
 
 For docker compose, this is as simple as adding a network with IPv6 enabled to your compose file. Upating the template from the project would look like this:
 
-```yaml
-services:
-  uptime-kuma:
-    image: louislam/uptime-kuma:1
-    volumes:
-      - ./data:/app/data
-    ports:
-      # <Host Port>:<Container Port>
-      - 3001:3001
-    restart: unless-stopped
-    networks:
-      - uptime-kuma-net
-networks:
-  uptime-kuma-net:
-    enable_ipv6: true
+```diff
+  services:
+    uptime-kuma:
+      image: louislam/uptime-kuma:1
+      volumes:
+        - ./data:/app/data
+      ports:
+        # <Host Port>:<Container Port>
+        - 3001:3001
+      restart: unless-stopped
++     networks:
++       - uptime-kuma-net
++ networks:
++   uptime-kuma-net:
++     enable_ipv6: true
 ```
 
 The network is created at the bottom, with `enable_ipv6: true` and then added to the service. 


### PR DESCRIPTION
Adding an example of a working compose file. 

This has been tested with docker compose on a machines with and without additional ipv6 config. It has not been tested on a machine that only has IPv4. 