### PR TITLE
docs: add zenith hosting badge

### DIFF
--- a/🔧-How-to-Install.md
+++ b/🔧-How-to-Install.md
@@ -117,6 +117,11 @@ Features:
 
 Deployment template of uptime-kuma on AWS using Terraform: https://github.com/paliwalvimal/uptime-kuma-aws
 
+### Zenith Hosting 
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/uptime-kuma?ref=gh)
+
+One-click deployment for Uptime Kuma, extremely cheap. 
+
 #### Home Assistant Add-on
 
 https://github.com/hassio-addons/addon-uptime-kuma


### PR DESCRIPTION
Added a deployment badge for Zenith, a one-click managed hosting platform where users can deploy Uptime Kuma, and we handle persistent storage, backups, etc. without the hassle of setting up a server.


ref: see https://github.com/louislam/uptime-kuma/pull/7552

